### PR TITLE
v1.3.0

### DIFF
--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
@@ -31,6 +31,9 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.Services
 				retVal.IsActive = store.Settings.GetSettingValue("GoogleEcommerceAnalytics.EnableTracking", false);
 			}
 
+			retVal.CreateECommerceTransaction = store.Settings.GetSettingValue("GoogleEcommerceAnalytics.CreateECommerceTransaction", false);
+			retVal.ReverseECommerceTransaction = store.Settings.GetSettingValue("GoogleEcommerceAnalytics.ReverseECommerceTransaction", true);
+
 			return retVal;
 		}
 	}

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/IGoogleAnalyticsSettingsManager.cs
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/IGoogleAnalyticsSettingsManager.cs
@@ -11,6 +11,9 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.Services
 		public string TrackingId { get; set; }
 		public bool IsActive { get; set; }
 		public string TrackingDomain { get; set; }
+
+		public bool CreateECommerceTransaction { get; set; }
+		public bool ReverseECommerceTransaction { get; set; }
 	}
 
 	public interface IGoogleAnalyticsSettingsManager

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/TransactionManagerTests.cs
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/TransactionManagerTests.cs
@@ -24,7 +24,14 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests
 
 		private IGoogleAnalyticsSettingsManager GetSettingsManager()
 		{
-			return Mock.Of<IGoogleAnalyticsSettingsManager>(s => s.Get(It.IsAny<string>()) == new GoogleAnalyticsSettings { IsActive = true, TrackingId = _googleAnalyticsTrackingId });
+			return Mock.Of<IGoogleAnalyticsSettingsManager>(s => s.Get(It.IsAny<string>()) == 
+				new GoogleAnalyticsSettings
+				{
+					IsActive = true,
+					CreateECommerceTransaction = true,
+					ReverseECommerceTransaction = true,
+					TrackingId = _googleAnalyticsTrackingId
+				});
 		}
 
 

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -6,7 +6,9 @@
 								"note": "Ecommerce Google Analytics module allows you to use the newly launched feature of Google Analytics – Enhanced Ecommerce.",
 								"is-active": "Is Active",
 								"gtm-id": "Google Tag Manager Id",
-								"ga-id": "Google Analytics Tracking Id"
+								"ga-id": "Google Analytics Tracking Id",
+								"createECommerceTransaction": "Send ecommerce transaction in GA when order is created",
+								"reverseECommerceTransaction": "Reverse ecommerce transaction from GA when order is canceled"
 							},
 							"placeholders": {
 								"gtm-id": "Enter Google Tag Manager Id",

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Properties/AssemblyInfo.cs
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.3.0.0")]

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/blades/store-settings.js
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/blades/store-settings.js
@@ -8,12 +8,15 @@
         blade.origEntity = data;
         blade.refresh();
         blade.isLoading = false;
-    };
+    }
 
     blade.refresh = function() {
-        blade.enableTracking = _.find(blade.currentEntities, function(x) { return x.name === 'GoogleEcommerceAnalytics.EnableTracking' });
-		blade.googleTagManagerId = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.GoogleTagManagerId' });
-		blade.googleAnalyticsTrackingId = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.GoogleAnalyticsTrackingId' });
+		blade.enableTracking = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.EnableTracking'; });
+		blade.createECommerceTransaction = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.CreateECommerceTransaction'; });
+		blade.reverseECommerceTransaction = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.ReverseECommerceTransaction'; });
+
+		blade.googleTagManagerId = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.GoogleTagManagerId'; });
+		blade.googleAnalyticsTrackingId = _.find(blade.currentEntities, function (x) { return x.name === 'GoogleEcommerceAnalytics.GoogleAnalyticsTrackingId'; });
     };
 
     function isDirty() {
@@ -25,9 +28,9 @@
         $scope.bladeClose();
     };
 
-    $scope.cancelChanges = function () {
-        $scope.bladeClose();
-    }
+	$scope.cancelChanges = function () {
+		$scope.bladeClose();
+	};
 
     $scope.blade.headIcon = 'fa-database';
 

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/blades/store-settings.tpl.html
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/blades/store-settings.tpl.html
@@ -24,6 +24,24 @@
 						<input ng-model="blade.googleAnalyticsTrackingId.value" type="text" placeholder="{{ 'google-ecommerce-analytics.blades.store-settings.placeholders.ga-id' | translate }}">
 					</div>
 				</div>
+				<div class="form-group">
+					<label class="form-label">{{ 'google-ecommerce-analytics.blades.store-settings.labels.createECommerceTransaction' | translate }}</label>
+					<div class="form-input">
+						<label class="form-label __switch">
+							<input type="checkbox" ng-model="blade.createECommerceTransaction.value" />
+							<span class="switch"></span>
+						</label>
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="form-label">{{ 'google-ecommerce-analytics.blades.store-settings.labels.reverseECommerceTransaction' | translate }}</label>
+					<div class="form-input">
+						<label class="form-label __switch">
+							<input type="checkbox" ng-model="blade.revertECommerceTransaction.value" />
+							<span class="switch"></span>
+						</label>
+					</div>
+				</div>
             </form>
         </div>
     </div>

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/google-ecommerce-analytics.js
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Scripts/google-ecommerce-analytics.js
@@ -8,7 +8,6 @@ if (AppDependencies != undefined) {
 angular.module(moduleName, [])
 .run(['platformWebApp.widgetService', 
 	function (widgetService) {
-	 
 	    // themes widget in STORE details
 	    widgetService.registerWidget({
 	        controller: 'virtoCommerce.googleEcommerceAnalyticsModule.storeSettingsWidgetController',

--- a/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
+++ b/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <module>
     <id>VirtoCommerce.GoogleEcommerceAnalytics</id>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <platformVersion>2.11.4</platformVersion>
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="2.14.0" />


### PR DESCRIPTION
Added additional settings:
* Send ecommerce transaction in GA as order is created. Default value: false
* Reverse ecommerce transaction from GA when order is canceled. Default vlaue: true

Note: If you turn on 'Send ecommerce transaction', it does not track your users, source and etc in GA #6. We recommend to send transaction from JavaScript on thank you page.