### PR TITLE
VCST-4194: Add GTM support to GA4 module and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Google Tag Manager provides a centralized way to manage all your tracking tags w
 1. Go to Store Settings in Virto Commerce Back Office
 1. Find the **Google Analytics 4** section
 1. Enable **GoogleAnalytics4.EnableTracking**
-1. Enter your **GTM Container Id** in **GoogleAnalytics4.GTMContainerId** (e.g., `GTM-XXXXXXX`)
+1. Enter your **GTM Container Id** in **GoogleAnalytics4.GtmContainerId** (e.g., `GTM-XXXXXXX`)
 1. *(Optional)* Enter your **Measurement Id** in **GoogleAnalytics4.MeasurementId** if you want both GTM and direct GA4 tracking
 1. Click **Save**
 
@@ -62,7 +62,7 @@ Google Tag Manager provides a centralized way to manage all your tracking tags w
 - **Load Order**: GTM loads first, ensuring proper event sequencing for all tags
 
 #### Important Notes
-- If both **GTMContainerId** and **MeasurementId** are provided, GTM will load first, followed by direct GA4
+- If both **GtmContainerId** and **MeasurementId** are provided, GTM will load first, followed by direct GA4
 - The module automatically pushes ecommerce events to `dataLayer` which GTM can capture
 - All standard ecommerce events (add_to_cart, purchase, etc.) are available in `dataLayer`
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# Integration with Google Analytics 4
-Google Analytics 4 module allows you to assign Google Analytics Measurement Id for a Store and measure traffic, ecommerce events to collect information about the shopping behaviour of your users.
+# Integration with Google Analytics 4 & Google Tag Manager
+Google Analytics 4 module allows you to assign Google Analytics Measurement Id and Google Tag Manager Container Id for a Store and measure traffic, ecommerce events to collect information about the shopping behaviour of your users. 
+
+The module supports both direct GA4 integration and advanced Google Tag Manager integration for centralized tag management.
 
 ## Key Features
 1. Store Configuration.
 1. Measure ecommerce with Vue B2B Theme and Virto Storefront.
+1. Google Tag Manager integration for advanced tracking and tag management.
 1. Ready for integration with other sales channels.
 1. Application menu.
 
@@ -11,23 +14,93 @@ Google Analytics 4 module allows you to assign Google Analytics Measurement Id f
 ![Google Analytics 4](docs/media/ga4-realtime.png)
 
 ## Setup
-1. [Create and Google Analytics Account](https://support.google.com/analytics/answer/9304153)
-1. Go to a Store Settings, select Settings and activate Google Analytics 4 and enter your Measurement Id.
 
-![How to find Measurement Id](https://storage.googleapis.com/support-kms-prod/4vzOnPW93ZjrGTZKfeIJYHXXPmpfCmc0UMHy)
+### Option 1: Direct GA4 Integration (Recommended for Simple Setups)
+1. [Create Google Analytics 4 Account](https://support.google.com/analytics/answer/9304153)
+1. Save your Measurement Id (format: `G-XXXXXXXXXX`)
+   
+   ![How to find Measurement Id](https://storage.googleapis.com/support-kms-prod/4vzOnPW93ZjrGTZKfeIJYHXXPmpfCmc0UMHy)
+
+1. Go to Store Settings in Virto Commerce Back Office
+1. Find the **Google Analytics 4** section
+1. Enable **GoogleAnalytics4.EnableTracking**
+1. Enter your **Measurement Id** in **GoogleAnalytics4.MeasurementId**
+1. Click **Save**
+
+### Option 2: Google Tag Manager Setup for GA4 (Recommended for Advanced Tracking)
+
+Google Tag Manager provides a centralized way to manage all your tracking tags without code changes. Use this option if you need:
+- Multiple tracking tools (GA4, Facebook Pixel, LinkedIn Insight, etc.)
+- Custom event tracking and triggers
+- A/B testing tools
+- Enhanced flexibility for marketing teams
+
+#### Step 1: Create Google Tag Manager Container
+1. [Create a Google Tag Manager account and container](https://support.google.com/tagmanager/answer/6103696)
+1. Save your Container ID (format: `GTM-XXXXXXX`)
+
+#### Step 2: Configure GA4 Tag in GTM
+1. In Google Tag Manager, create a new **Google Analytics: GA4 Configuration** tag
+1. Enter your GA4 Measurement ID
+1. Set the trigger to **All Pages** or **Initialization - All Pages**
+1. Configure any additional parameters (user properties, custom dimensions, etc.)
+1. Save and publish your container
+
+#### Step 3: Configure Virto Commerce Store Settings
+1. Go to Store Settings in Virto Commerce Back Office
+1. Find the **Google Analytics 4** section
+1. Enable **GoogleAnalytics4.EnableTracking**
+1. Enter your **GTM Container Id** in **GoogleAnalytics4.GTMContainerId** (e.g., `GTM-XXXXXXX`)
+1. *(Optional)* Enter your **Measurement Id** in **GoogleAnalytics4.MeasurementId** if you want both GTM and direct GA4 tracking
+1. Click **Save**
+
+#### GTM + GA4 Integration Benefits
+- **Centralized Management**: Update tracking configurations without code deployments
+- **Enhanced Events**: Leverage `dataLayer` for rich ecommerce events
+- **Multiple Tags**: Add other marketing and analytics tools easily
+- **Testing**: Preview and debug tags before publishing
+- **Load Order**: GTM loads first, ensuring proper event sequencing for all tags
+
+#### Important Notes
+- If both **GTMContainerId** and **MeasurementId** are provided, GTM will load first, followed by direct GA4
+- The module automatically pushes ecommerce events to `dataLayer` which GTM can capture
+- All standard ecommerce events (add_to_cart, purchase, etc.) are available in `dataLayer`
 
 ## Integration with Virto Storefront
 Virto Storefront and Vue B2B Theme has native integration with Google Analytics 4 module. 
 Once you click Save for Store Settings, the Google Analytics tracking will be activated.
 
-We measures the following actions:
+### Supported Ecommerce Events
+The module automatically tracks the following ecommerce actions and pushes them to `dataLayer`:
 
-* Select an item from a category
-* View product details
-* Add/remove a product from a shopping cart
-* Initiate the checkout process
-* Make purchases or refunds
-* Apply promotions
+* **view_item** - View product details
+* **select_item** - Select an item from a category
+* **add_to_cart** - Add a product to shopping cart
+* **remove_from_cart** - Remove a product from shopping cart
+* **view_cart** - View shopping cart
+* **begin_checkout** - Initiate the checkout process
+* **add_shipping_info** - Add shipping information
+* **add_payment_info** - Add payment information
+* **purchase** - Complete purchases
+* **refund** - Process refunds
+* **view_promotion** - View promotions
+* **select_promotion** - Apply promotions
+
+### GTM Event Tracking (Optional Setup)
+If you're using GTM, you can capture these events by creating **GA4 Event** tags in GTM:
+
+1. In GTM, create a new **Google Analytics: GA4 Event** tag
+1. Set **Configuration Tag** to your GA4 Configuration tag
+1. Set **Event Name** to a custom variable that reads from `dataLayer` (e.g., `{{Event}}`)
+1. Set the trigger to **Custom Event** matching the ecommerce events listed above
+1. Optionally, pass additional parameters using variables from `dataLayer`
+1. Save and publish your container
+
+This allows you to:
+- Customize event names before sending to GA4
+- Add conditional logic to events
+- Send events to multiple analytics platforms
+- Debug events in GTM Preview mode
 
 ## Application Menu 
 The module adds `Google Analytics` link into Application menu. It redirects to Google Analytics Dashboard. You could customize Google Analytics Dashboard Url in Platform Settings.
@@ -36,6 +109,9 @@ The module adds `Google Analytics` link into Application menu. It redirects to G
 
 ## Documentation
 * [Google Analytics 4](https://developers.google.com/analytics/devguides/collection/ga4)
+* [Google Tag Manager](https://developers.google.com/tag-platform/tag-manager)
+* [GTM with GA4 Setup Guide](https://support.google.com/tagmanager/answer/9442095)
+* [GA4 Ecommerce Events](https://developers.google.com/analytics/devguides/collection/ga4/ecommerce)
 * [Module Documentation](https://docs.virtocommerce.org/modules/google-ecommerce-analytics/)
 * [View on GitHub](docs/index.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,13 @@
 # Overview
 
-Google Analytics 4 module allows you to assign Google Analytics Measurement Id for a Store and measure traffic, ecommerce events to collect information about the shopping behaviour of your users.
+Google Analytics 4 module allows you to assign Google Analytics Measurement Id and Google Tag Manager Container Id for a Store and measure traffic, ecommerce events to collect information about the shopping behaviour of your users.
 
 ![Google Analytics 4](https://developers.google.com/static/analytics/images/md_collection.svg)
 
 ## Key Features
 1. Store Configuration.
 1. Measure ecommerce with Vue B2B Theme and Virto Storefront via Google tag.
+1. Google Tag Manager integration for advanced tracking and tag management.
 1. Ready for integration with other sales channels.
 1. Application menu.
 
@@ -14,20 +15,31 @@ Google Analytics 4 module allows you to assign Google Analytics Measurement Id f
 ![Google Analytics 4](media/ga4-realtime.png)
 
 ## Setup
+
+### Google Analytics 4 Setup
 First, [Create and configure Google Analytics 4 Account](https://support.google.com/analytics/answer/9304153)
 
 Save your Measurement Id.
 
 ![How to find Measurement Id](https://storage.googleapis.com/support-kms-prod/4vzOnPW93ZjrGTZKfeIJYHXXPmpfCmc0UMHy)
 
+### Google Tag Manager Setup (Optional)
+If you want to use Google Tag Manager for advanced tracking and tag management:
+
+1. [Create a Google Tag Manager account and container](https://support.google.com/tagmanager/answer/6103696)
+1. Save your Container ID (format: `GTM-XXXXXXX`)
+
+### Configure Store Settings
 1. Open Virto Commerce Back Office.
 1. Select Store and Open Store Settings.
 1. Find Google Analytics 4 section.
-1. Enable Google Analytics and enter your Measurement Id.
+1. Enable Google Analytics tracking.
+1. Enter your Measurement Id (required for GA4 tracking).
+1. Enter your GTM Container Id (optional, for Google Tag Manager integration).
 
 ![ga4 store settings](media/screen-ga4-store-settings.png)
 
-Once you click Save for Store, the Google Analytics tracking will be activated.
+Once you click Save for Store, the tracking will be activated. If both Measurement Id and GTM Container Id are provided, GTM will be loaded first, followed by GA4, ensuring proper event sequencing.
 
 ## Integration with Virto Storefront
 Virto Storefront and Vue B2B Theme has native integration with Google Analytics 4 module. 
@@ -50,10 +62,11 @@ The module adds Google Analytics link into Application menu. It redirects to Goo
 You can use either Store settings or Rest API to request Google Analytics configuration for store.
 
 ## Settings
-Google Analytics 4 module defines two store settings:
+Google Analytics 4 module defines the following store settings:
 
-1. GoogleAnalytics4.EnableTracking
-1. GoogleAnalytics4.MeasurementId
+1. **GoogleAnalytics4.EnableTracking** - Enable or disable tracking (applies to both GA4 and GTM)
+1. **GoogleAnalytics4.MeasurementId** - Google Analytics 4 Measurement ID (e.g., `G-XXXXXXXXXX`)
+1. **GoogleAnalytics4.GTMContainerId** - Google Tag Manager Container ID (e.g., `GTM-XXXXXXX`)
 
 ## Rest API
 
@@ -70,7 +83,8 @@ Response:
 ```json
 {
   "enableTracking": true,
-  "measurementId": "G-1234567890"
+  "measurementId": "G-1234567890",
+  "gtmContainerId": "GTM-XXXXXXX"
 }
 ```
 

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/Models/GoogleAnalyticsSettings.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/Models/GoogleAnalyticsSettings.cs
@@ -4,5 +4,6 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.Models
     {
         public bool EnableTracking { get; set; }
         public string MeasurementId { get; set; }
+        public string GTMContainerId { get; set; }
     }
 }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/Models/GoogleAnalyticsSettings.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/Models/GoogleAnalyticsSettings.cs
@@ -4,6 +4,6 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.Models
     {
         public bool EnableTracking { get; set; }
         public string MeasurementId { get; set; }
-        public string GTMContainerId { get; set; }
+        public string GtmContainerId { get; set; }
     }
 }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/ModuleConstants.cs
@@ -37,6 +37,14 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                     IsPublic = true
                 };
 
+                public static SettingDescriptor GTMContainerId { get; } = new SettingDescriptor
+                {
+                    Name = "GoogleAnalytics4.GTMContainerId",
+                    GroupName = "Google Analytics 4",
+                    ValueType = SettingValueType.ShortText,
+                    IsPublic = true
+                };
+
                 public static SettingDescriptor GoogleAnalyticsUrl { get; } = new SettingDescriptor
                 {
                     Name = "GoogleAnalytics4.GoogleAnalyticsUrl",
@@ -52,6 +60,7 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                         yield return EnableTracking;
                         yield return MeasurementId;
                         yield return GoogleAnalyticsUrl;
+                        yield return GTMContainerId;
                     }
                 }
             }
@@ -62,6 +71,7 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                 {
                     yield return General.EnableTracking;
                     yield return General.MeasurementId;
+                    yield return General.GTMContainerId;
                 }
             }
         }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/ModuleConstants.cs
@@ -37,9 +37,9 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                     IsPublic = true
                 };
 
-                public static SettingDescriptor GTMContainerId { get; } = new SettingDescriptor
+                public static SettingDescriptor GtmContainerId { get; } = new SettingDescriptor
                 {
-                    Name = "GoogleAnalytics4.GTMContainerId",
+                    Name = "GoogleAnalytics4.GtmContainerId",
                     GroupName = "Google Analytics 4",
                     ValueType = SettingValueType.ShortText,
                     IsPublic = true
@@ -60,7 +60,7 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                         yield return EnableTracking;
                         yield return MeasurementId;
                         yield return GoogleAnalyticsUrl;
-                        yield return GTMContainerId;
+                        yield return GtmContainerId;
                     }
                 }
             }
@@ -71,7 +71,7 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Core
                 {
                     yield return General.EnableTracking;
                     yield return General.MeasurementId;
-                    yield return General.GTMContainerId;
+                    yield return General.GtmContainerId;
                 }
             }
         }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
@@ -28,10 +28,10 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.Services
             }
 
             retVal.MeasurementId = store.Settings.GetValue<string>(GoogleSettings.MeasurementId);
-            retVal.GTMContainerId = store.Settings.GetValue<string>(GoogleSettings.GTMContainerId);
+            retVal.GtmContainerId = store.Settings.GetValue<string>(GoogleSettings.GtmContainerId);
 
-            // Enable tracking if either MeasurementId or GTMContainerId is provided
-            if (!string.IsNullOrEmpty(retVal.MeasurementId) || !string.IsNullOrEmpty(retVal.GTMContainerId))
+            // Enable tracking if either MeasurementId or GtmContainerId is provided
+            if (!string.IsNullOrEmpty(retVal.MeasurementId) || !string.IsNullOrEmpty(retVal.GtmContainerId))
             {
                 retVal.EnableTracking = store.Settings.GetValue<bool>(GoogleSettings.EnableTracking);
             }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/Services/GoogleAnalyticsSettingsManager.cs
@@ -28,7 +28,10 @@ namespace VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.Services
             }
 
             retVal.MeasurementId = store.Settings.GetValue<string>(GoogleSettings.MeasurementId);
-            if (!string.IsNullOrEmpty(retVal.MeasurementId))
+            retVal.GTMContainerId = store.Settings.GetValue<string>(GoogleSettings.GTMContainerId);
+
+            // Enable tracking if either MeasurementId or GTMContainerId is provided
+            if (!string.IsNullOrEmpty(retVal.MeasurementId) || !string.IsNullOrEmpty(retVal.GTMContainerId))
             {
                 retVal.EnableTracking = store.Settings.GetValue<bool>(GoogleSettings.EnableTracking);
             }

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/de.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/de.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Mess-ID",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "GTM-Container-ID",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/de.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/de.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Mess-ID",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "GTM-Container-ID",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "Google Analytics-Dashboard-URL",
         "description": "Google Analytics-Dashboard-URL für die Umleitung aus dem App-Menü"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Measurement Id",
         "description": "Specify the Google Analytics measurement ID (G-XXXXXXXXX)"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "GTM Container Id",
         "description": "Specify the Google Tag Manager container ID (GTM-XXXXXXX)"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/en.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Measurement Id",
         "description": "Specify the Google Analytics measurement ID (G-XXXXXXXXX)"
       },
+      "GTMContainerId": {
+        "title": "GTM Container Id",
+        "description": "Specify the Google Tag Manager container ID (GTM-XXXXXXX)"
+      },
       "GoogleAnalyticsUrl": {
         "title": "Google Analytics dashboard URL",
         "description": "Provide the URL for the Google Analytics dashboard for redirecting from App Menu"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/es.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/es.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Id de medición",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "Id de contenedor GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL del panel de control de Google Analytics",
         "description": "URL del panel de control de Google Analytics para redirigir desde el menú de la aplicación"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/es.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/es.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Id de medición",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "Id de contenedor GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/fr.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/fr.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Identifiant de mesure",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "Identifiant de conteneur GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/fr.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/fr.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Identifiant de mesure",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "Identifiant de conteneur GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL du tableau de bord Google Analytics",
         "description": "URL du tableau de bord Google Analytics pour redirection depuis le menu de l'application"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/it.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/it.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "ID di misurazione",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "ID contenitore GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL del dashboard di Google Analytics",
         "description": "URL del dashboard di Google Analytics per il reindirizzamento dal menu dell'app"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/it.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/it.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "ID di misurazione",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "ID contenitore GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ja.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ja.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "測定 ID",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "GTM コンテナ ID",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ja.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ja.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "測定 ID",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "GTM コンテナ ID",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "Google Analytics ダッシュボード URL",
         "description": "アプリ メニューからリダイレクトするための Google Analytics ダッシュボード URL"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pl.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pl.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Identyfikator pomiaru",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "Identyfikator kontenera GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL panelu Google Analytics",
         "description": "URL panelu Google Analytics do przekierowania z menu aplikacji"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pl.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pl.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Identyfikator pomiaru",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "Identyfikator kontenera GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pt.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pt.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "ID de medição",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "ID do contêiner GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL do painel do Google Analytics",
         "description": "URL do painel do Google Analytics para redirecionamento do Menu do Aplicativo"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pt.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/pt.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "ID de medição",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "ID do contêiner GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ru.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ru.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "Идентификатор измерений",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "Идентификатор контейнера GTM",
         "description": "GTM-XXXXXXX"
       },

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ru.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/ru.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "Идентификатор измерений",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "Идентификатор контейнера GTM",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "URL панели управления Google Analytics",
         "description": "URL панели управления Google Analytics для перенаправления из меню приложения"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/zh.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/zh.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,6 +9,10 @@
         "title": "测量 ID",
         "description": "G-XXXXXXXXX"
       },
+      "GTMContainerId": {
+        "title": "GTM 容器 ID",
+        "description": "GTM-XXXXXXX"
+      },
       "GoogleAnalyticsUrl": {
         "title": "Google Analytics 仪表板 URL",
         "description": "从应用菜单重定向的 Google Analytics 仪表板 URL"

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/zh.VirtoCommerce.GoogleEcommerceAnalytics.json
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/Localizations/zh.VirtoCommerce.GoogleEcommerceAnalytics.json
@@ -9,7 +9,7 @@
         "title": "测量 ID",
         "description": "G-XXXXXXXXX"
       },
-      "GTMContainerId": {
+      "GtmContainerId": {
         "title": "GTM 容器 ID",
         "description": "GTM-XXXXXXX"
       },


### PR DESCRIPTION
## Description
feat: Enhanced the Google Analytics 4 module by integrating Google Tag Manager (GTM) for advanced tracking and tag management.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4194
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.GoogleEcommerceAnalytics_4.805.0-pr-53-6191.zip