### PR TITLE
VCST-4203: Remove obsolete code

### DIFF
--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.809.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.823.0-alpha.763-vcst-4203-cleanup" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj" />

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.823.0-alpha.763-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.823.0-alpha.766-vcst-4203-cleanup" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj" />

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.823.0-alpha.766-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.823.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj" />

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>4.806.0</version>
   <version-tag />
 
-  <platformVersion>3.853.0</platformVersion>
+  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Store" version="3.809.0" />
+    <dependency id="VirtoCommerce.Store" version="3.823.0-alpha.763-vcst-4203-cleanup" />
   </dependencies>
 
   <apps>
@@ -29,7 +29,7 @@
   <iconUrl>Modules/$(VirtoCommerce.GoogleEcommerceAnalytics)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
   <tags>analytics</tags>
   <assemblyFile>VirtoCommerce.GoogleEcommerceAnalyticsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.GoogleEcommerceAnalyticsModule.Web.Module, VirtoCommerce.GoogleEcommerceAnalyticsModule.Web</moduleType>

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>4.806.0</version>
   <version-tag />
 
-  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
+  <platformVersion>3.917.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Store" version="3.823.0-alpha.766-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Store" version="3.823.0" />
   </dependencies>
 
   <apps>

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Store" version="3.823.0-alpha.763-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Store" version="3.823.0-alpha.766-vcst-4203-cleanup" />
   </dependencies>
 
   <apps>

--- a/tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests.csproj
+++ b/tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Required modules list URL:
https://github.com/VirtoCommerce/vc-modules/raw/refs/heads/VCST-4203-cleanup/update/modules.json
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4203
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.GoogleEcommerceAnalytics_4.806.0-pr-54-d4eb.zip