### PR TITLE
VCST-5163: Stable 15 — GoogleEcommerceAnalytics (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core/VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj
@@ -13,6 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data/VirtoCommerce.GoogleEcommerceAnalyticsModule.Data.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core\VirtoCommerce.GoogleEcommerceAnalyticsModule.Core.csproj" />

--- a/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
+++ b/src/VirtoCommerce.GoogleEcommerceAnalyticsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>4.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
   </dependencies>
 
   <apps>

--- a/tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests.csproj
+++ b/tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests/VirtoCommerce.GoogleEcommerceAnalyticsModule.Tests.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 4). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–3 packages on nuget.org. Version handled by CI.

- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency and manifest updates with no runtime or security logic changes.
> 
> **Overview**
> **Stable 15 alignment** for the Google Ecommerce Analytics module: dependency and manifest versions only, no application logic changes.
> 
> **VirtoCommerce.Platform.Core** is raised from `3.1002.0` to **`3.1039.0`** in Core, and **`module.manifest`** `platformVersion` matches. **VirtoCommerce.StoreModule.Core** / **VirtoCommerce.Store** move from `3.1000.0` to **`3.1005.0`** in Data and the manifest. The test project bumps **coverlet.collector** from `8.0.0` to **`10.0.1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae7b53c64a3ee4647c3744b22539026f4cd63bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.GoogleEcommerceAnalytics_4.1002.0-pr-60-ae7b.zip